### PR TITLE
Issues/11 in game config reloading

### DIFF
--- a/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
@@ -94,5 +94,6 @@ public final class AchievementBorder extends JavaPlugin {
   }
   
   private void registerCommands() {
+    new ConfigCommand(this);
   }
 }

--- a/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
@@ -93,6 +93,12 @@ public final class AchievementBorder extends JavaPlugin {
             .register();
   }
   
+  /**
+   * Helper function to register commands
+   *
+   * @author sh0ckR6
+   * @since 1.1
+   */
   private void registerCommands() {
     new ConfigCommand(this);
   }

--- a/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
@@ -1,17 +1,13 @@
 package com.github.sh0ckr6.achievementborder;
 
 import com.github.sh0ckr6.achievementborder.builders.ShapedRecipeBuilder;
+import com.github.sh0ckr6.achievementborder.commands.ConfigCommand;
 import com.github.sh0ckr6.achievementborder.listeners.BorderControl;
 import com.github.sh0ckr6.achievementborder.listeners.WorldSetup;
 import com.github.sh0ckr6.achievementborder.managers.ConfigManager;
+import org.bukkit.Material;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.advancement.Advancement;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
@@ -35,6 +31,7 @@ public final class AchievementBorder extends JavaPlugin {
     new BorderControl(this);
     new WorldSetup(this);
     
+    registerCommands();
     registerRecipes();
   }
   
@@ -94,5 +91,8 @@ public final class AchievementBorder extends JavaPlugin {
             .setIngredient('E', Material.END_STONE)
             .setIngredient('O', Material.OBSIDIAN)
             .register();
+  }
+  
+  private void registerCommands() {
   }
 }

--- a/src/main/java/com/github/sh0ckr6/achievementborder/commands/BaseCommand.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/commands/BaseCommand.java
@@ -6,19 +6,61 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Base command class that all commands extend. Allows for easy creation of
+ * new commands without having to rewrite boilerplate code.
+ *
+ * @author sh0ckR6
+ * @since 1.1
+ */
 public abstract class BaseCommand implements CommandExecutor {
   
+  /**
+   * A reference to the current plugin
+   *
+   * @since 1.1
+   */
   protected AchievementBorder plugin;
   
+  /**
+   * Registers this class as a {@link CommandExecutor} for the given command
+   *
+   * @param plugin The plugin to register this to
+   * @param name The name of the command to register
+   * @author sh0ckR6
+   * @since 1.1
+   */
   public BaseCommand(AchievementBorder plugin, String name) {
     this.plugin = plugin;
     plugin.getCommand(name).setExecutor(this);
   }
   
+  /**
+   * Run when a {@link CommandSender} executes any command
+   *
+   * @param sender The sender of the command
+   * @param command The {@link Command} that was run
+   * @param label The name of the command
+   * @param args The arguments passed to the command
+   * @return If the command was successfully executed
+   * @author sh0ckR6
+   * @since 1.1
+   */
   @Override
   public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
     return execute(sender, command, label, args);
   }
   
+  /**
+   * Extended by this class's children, after passing all checks in {@link #onCommand}, this function will be run
+   *
+   * @param sender The sender of the command
+   * @param command The {@link Command} that was run
+   * @param label The name of the command
+   * @param args The arguments passed to the command
+   * @return If the command was successfully executed
+   * @author sh0ckR6
+   * @since 1.1
+   */
   protected abstract boolean execute(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args);
 }

--- a/src/main/java/com/github/sh0ckr6/achievementborder/commands/BaseCommand.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/commands/BaseCommand.java
@@ -1,0 +1,24 @@
+package com.github.sh0ckr6.achievementborder.commands;
+
+import com.github.sh0ckr6.achievementborder.AchievementBorder;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class BaseCommand implements CommandExecutor {
+  
+  protected AchievementBorder plugin;
+  
+  public BaseCommand(AchievementBorder plugin, String name) {
+    this.plugin = plugin;
+    plugin.getCommand(name).setExecutor(this);
+  }
+  
+  @Override
+  public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    return execute(sender, command, label, args);
+  }
+  
+  protected abstract boolean execute(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args);
+}

--- a/src/main/java/com/github/sh0ckr6/achievementborder/commands/ConfigCommand.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/commands/ConfigCommand.java
@@ -3,15 +3,40 @@ package com.github.sh0ckr6.achievementborder.commands;
 import com.github.sh0ckr6.achievementborder.AchievementBorder;
 import com.github.sh0ckr6.achievementborder.managers.ConfigManager;
 import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * {@link BaseCommand} class representing the <code>/config</code> command
+ *
+ * @author sh0ckR6
+ * @since 1.1
+ */
 public class ConfigCommand extends BaseCommand {
   
+  /**
+   * Registers this class as a {@link CommandExecutor} for the given command
+   *
+   * @param plugin The plugin to register this to
+   * @author sh0ckR6
+   * @since 1.1
+   */
   public ConfigCommand(AchievementBorder plugin) {
     super(plugin, "config");
   }
   
+  /**
+   * Extended from this class's parent, after passing all checks in {@link #onCommand}, this function will be run
+   *
+   * @param sender The sender of the command
+   * @param command The {@link Command} that was run
+   * @param label The name of the command
+   * @param args The arguments passed to the command
+   * @return If the command was successfully executed
+   * @author sh0ckR6
+   * @since 1.1
+   */
   @Override
   protected boolean execute(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
     if (args[0].equalsIgnoreCase("reload")) {

--- a/src/main/java/com/github/sh0ckr6/achievementborder/commands/ConfigCommand.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/commands/ConfigCommand.java
@@ -1,0 +1,22 @@
+package com.github.sh0ckr6.achievementborder.commands;
+
+import com.github.sh0ckr6.achievementborder.AchievementBorder;
+import com.github.sh0ckr6.achievementborder.managers.ConfigManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+public class ConfigCommand extends BaseCommand {
+  
+  public ConfigCommand(AchievementBorder plugin) {
+    super(plugin, "config");
+  }
+  
+  @Override
+  protected boolean execute(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    if (args[0].equalsIgnoreCase("reload")) {
+      ConfigManager.reloadConfigs(plugin);
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/github/sh0ckr6/achievementborder/managers/ConfigManager.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/managers/ConfigManager.java
@@ -1,5 +1,6 @@
 package com.github.sh0ckr6.achievementborder.managers;
 
+import com.github.sh0ckr6.achievementborder.AchievementBorder;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -211,5 +212,10 @@ public class ConfigManager {
     } catch (IOException e) {
       e.printStackTrace();
     }
+  }
+  
+  public static void reloadConfigs(AchievementBorder plugin) {
+    configurations = new HashMap<>();
+    loadAllConfigs(plugin);
   }
 }

--- a/src/main/java/com/github/sh0ckr6/achievementborder/managers/ConfigManager.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/managers/ConfigManager.java
@@ -214,6 +214,13 @@ public class ConfigManager {
     }
   }
   
+  /**
+   * Reload all {@link YamlConfiguration}s from disk
+   *
+   * @param plugin The current plugin
+   * @author sh0ckR6
+   * @since 1.1
+   */
   public static void reloadConfigs(AchievementBorder plugin) {
     configurations = new HashMap<>();
     loadAllConfigs(plugin);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,7 @@ prefix: ACHV-BORDER
 authors: [ sh0ckR6 ]
 description: Gradually expand your world the more achievements you get!
 website: https://github.com/sh0ckR6
+commands:
+  config:
+    description: Change configuration settings
+    usage: /config reload


### PR DESCRIPTION
##### Linked PRs and Issues
* ###### Resolves #11 
* ###### Resolves #12 

## Overview
Allow player to reload configuration files without reloading server

### Command System
This PR also creates an internal command system that can be reused later to easily create new commands

### `/config` command
Manage the configuration files
#### `/config reload`
* Reload all configuration files