### PR TITLE
Add new Configuration option "borders"

### DIFF
--- a/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/AchievementBorder.java
@@ -6,13 +6,17 @@ import com.github.sh0ckr6.achievementborder.listeners.BorderControl;
 import com.github.sh0ckr6.achievementborder.listeners.MobControl;
 import com.github.sh0ckr6.achievementborder.listeners.WorldSetup;
 import com.github.sh0ckr6.achievementborder.managers.ConfigManager;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public final class AchievementBorder extends JavaPlugin {
   
@@ -67,6 +71,11 @@ public final class AchievementBorder extends JavaPlugin {
     config.addDefault("setup-complete", false);
     config.addDefault("starting-size", 1);
     config.addDefault("advancements", new String[]{});
+    Map<String, Boolean> borderWorlds = new HashMap<>();
+    for (World world : Bukkit.getWorlds()) {
+      borderWorlds.put(world.getName(), false);
+    }
+    config.addDefault("borders", borderWorlds);
     config.options().copyDefaults(true);
     ConfigManager.saveConfig(config);
   }

--- a/src/main/java/com/github/sh0ckr6/achievementborder/listeners/BorderControl.java
+++ b/src/main/java/com/github/sh0ckr6/achievementborder/listeners/BorderControl.java
@@ -3,10 +3,10 @@ package com.github.sh0ckr6.achievementborder.listeners;
 import com.github.sh0ckr6.achievementborder.AchievementBorder;
 import com.github.sh0ckr6.achievementborder.managers.ConfigManager;
 import org.bukkit.Bukkit;
-import org.bukkit.World;
 import org.bukkit.WorldBorder;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -16,6 +16,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Listener class to handle events relating to controlling the world border
@@ -72,7 +73,7 @@ public class BorderControl implements Listener {
       }
     }
     
-    updateBorder(Bukkit.getWorlds().get(0).getWorldBorder());
+    updateBorders();
   }
   
   /**
@@ -101,17 +102,7 @@ public class BorderControl implements Listener {
       }
     }
   
-    updateBorder(Bukkit.getWorlds().get(0).getWorldBorder());
-  }
-  
-  /**
-   * Helper function to update a world's border.
-   * @param border The border to update
-   * @author sh0ckR6
-   * @since 1.0
-   */
-  private void updateBorder(WorldBorder border) {
-    border.setSize(plugin.advancements.size() * 5 + ConfigManager.<Integer>readFromConfig("config", "starting-size"), 1);
+    updateBorders();
   }
   
   /**
@@ -157,7 +148,27 @@ public class BorderControl implements Listener {
       }
     }
     
-    updateBorder(Bukkit.getWorlds().get(0).getWorldBorder());
+    updateBorders();
+  }
+  
+  /**
+   * Helper function to update a world's border.
+   * @author sh0ckR6
+   * @since 1.0
+   */
+  private void updateBorders() {
+    // Get a list of every registered world that needs to have its border updated
+    YamlConfiguration config = ConfigManager.getConfig("config");
+    Map<String, Object> worldBorders = config.getConfigurationSection("borders").getValues(false);
+    for (String worldName : worldBorders.keySet()) {
+      
+      try {
+        Bukkit.getWorld(worldName).getWorldBorder().setSize(((boolean) worldBorders.get(worldName) ? plugin.advancements.size() * 5 + ConfigManager.<Integer>readFromConfig("config", "starting-size") : 60000000), 1);
+      } catch (NullPointerException e) {
+        // If we couldn't get the world, log it
+        Bukkit.getLogger().severe("Invalid world name found in 'config.yml/borders': " + worldName);
+      }
+    }
   }
   
   /**


### PR DESCRIPTION
## Overview
This pull request adds a new configuration section `borders` which defines what worlds should be affected by the Border Control System.

## Configuration System
##### config.yml
```yaml
borders:
  world: true
  world_nether: false
  world_end: true
  # etc...
```
* `borders` Configuration section defines which worlds should be affected by the Border Control System

## Border Control System
* Updated "updateBorder" function
  * Renamed to "updateBorders"
  * Now uses configuration settings to determine which worlds to update the border for
* Minor cleanup around the BorderControl class

## Linked Issues and Pull Requests
#### Issues
* #17 

### Pull Requests
_N/A_